### PR TITLE
Comply with strict standards 5.4+

### DIFF
--- a/app/backend/Module.php
+++ b/app/backend/Module.php
@@ -22,7 +22,7 @@ class Module implements \Phalcon\Mvc\ModuleDefinitionInterface
      *
      * @return void
      */
-    public function registerAutoloaders($di = null)
+    public function registerAutoloaders(\Phalcon\DiInterface $di = null)
     {
         $loader = new \Phalcon\Loader();
 
@@ -43,7 +43,7 @@ class Module implements \Phalcon\Mvc\ModuleDefinitionInterface
      *
      * @return void
      */
-    public function registerServices($di)
+    public function registerServices(\Phalcon\DiInterface $di)
     {
         //Registering a dispatcher
         $di->set('dispatcher', function() {

--- a/app/cli/Module.php
+++ b/app/cli/Module.php
@@ -22,7 +22,7 @@ class Module implements \Phalcon\Mvc\ModuleDefinitionInterface
      *
      * @return void
      */
-    public function registerAutoloaders($di = null)
+    public function registerAutoloaders(\Phalcon\DiInterface $di = null)
     {
         $loader = new \Phalcon\Loader();
 
@@ -43,7 +43,7 @@ class Module implements \Phalcon\Mvc\ModuleDefinitionInterface
      *
      * @return void
      */
-    public function registerServices($di)
+    public function registerServices(\Phalcon\DiInterface $di)
     {
         //Registering a dispatcher
         $di->set('dispatcher', function() {

--- a/app/documentation/Module.php
+++ b/app/documentation/Module.php
@@ -22,7 +22,7 @@ class Module implements \Phalcon\Mvc\ModuleDefinitionInterface
      *
      * @return void
      */
-    public function registerAutoloaders($di = null)
+    public function registerAutoloaders(\Phalcon\DiInterface $di = null)
     {
         $loader = new \Phalcon\Loader();
 
@@ -43,7 +43,7 @@ class Module implements \Phalcon\Mvc\ModuleDefinitionInterface
      *
      * @return void
      */
-    public function registerServices($di)
+    public function registerServices(\Phalcon\DiInterface $di)
     {
         //Registering a dispatcher
         $di->set('dispatcher', function() {

--- a/app/frontend/Module.php
+++ b/app/frontend/Module.php
@@ -22,7 +22,7 @@ class Module implements \Phalcon\Mvc\ModuleDefinitionInterface
      *
      * @return void
      */
-    public function registerAutoloaders($di = null)
+    public function registerAutoloaders(\Phalcon\DiInterface $di = null)
     {
         $loader = new \Phalcon\Loader();
 
@@ -43,7 +43,7 @@ class Module implements \Phalcon\Mvc\ModuleDefinitionInterface
      *
      * @return void
      */
-    public function registerServices($di)
+    public function registerServices(\Phalcon\DiInterface $di)
     {
         //Registering a dispatcher
         $di->set('dispatcher', function() {


### PR DESCRIPTION
```
PHP Fatal error:  Declaration of Baseapp\\Frontend\\Module::registerAutoloaders() must be compatible with Phalcon\\Mvc\\ModuleDefinitionInterface::registerAutoloaders(Phalcon\\DiInterface $dependencyInjector = NULL) in /home/realtimesolutions/Web/app/frontend/Module.php on line 13
```

Simple change to comply with standards, and eliminate errors being produced in strict environments.